### PR TITLE
Use echo rather than here string to satisfy non-bash shells.

### DIFF
--- a/ssh-ssm.sh
+++ b/ssh-ssm.sh
@@ -36,7 +36,7 @@ aws ssm send-command \
   --instance-ids "$1" \
   --document-name 'AWS-RunShellScript' \
   --parameters commands="\"
-    u=\$(getent passwd ${ssh_user}) && x=\$(cut -d: -f6 <<<\$u) || exit 1
+    u=\$(getent passwd ${ssh_user}) && x=\$(echo \$u |cut -d: -f6) || exit 1
     grep '${ssh_pubkey}' \${x}/${ssh_authkeys} && exit 1
     printf '${ssh_pubkey}'|tee -a \${x}/${ssh_authkeys} && sleep 15
     sed -i s,'${ssh_pubkey}',, \${x}/${ssh_authkeys}


### PR DESCRIPTION
Thanks much for pointing out an easier fix in #3!

This allows non-bash shells to execute the RunCommand document properly. 