### PR TITLE
Fix for basename error on strings that start with a dash

### DIFF
--- a/ssh-ssm.sh
+++ b/ssh-ssm.sh
@@ -29,7 +29,7 @@ EOF
 function checks {
   [[ $# -ne 2 ]] && die "Usage: ${0##*/} <instance-id> <ssh user>"
   [[ ! $1 =~ ^i-([0-9a-f]{8,})$ ]] && die "ERROR: invalid instance-id"
-  if [[ $(basename $(ps -o comm= -p $PPID)) != "ssh" ]]; then
+  if [[ $(basename -- $(ps -o comm= -p $PPID)) != "ssh" ]]; then
     ssh -o IdentityFile="~/.ssh/ssm-ssh-tmp" -o ProxyCommand="${0} ${1} ${2}" "${2}@${1}"
     exit 0
   fi


### PR DESCRIPTION
Whenever running ssh-ssm.sh on Mac and zsh, I noticed an error with basename, which originates from the parent process' name that starts with a dash. Simply adding a double dash after basename fixes it.

```
+++ ps -o comm= -p 76223
++ basename -zsh
basename: illegal option -- z
usage: basename string [suffix]
       basename [-a] [-s suffix] string [...]
+ [[ '' != \s\s\h ]]
```

After the fix:

```
+++ ps -o comm= -p 76223
++ basename -- -zsh
+ [[ -zsh != \s\s\h ]]
```