### PR TITLE
added newline after pub key in remote authorized_keys

### DIFF
--- a/ssh-ssm.sh
+++ b/ssh-ssm.sh
@@ -18,7 +18,7 @@ main () {
     "u=\$(getent passwd ${2}) && x=\$(echo \$u |cut -d: -f6) || exit 1
     [ ! -d \${x}/.ssh ] && install -d -m700 -o${2} \${x}/.ssh
     grep '${ssh_pubkey}' \${x}/${ssh_authkeys} && exit 0
-    printf '${ssh_pubkey}'|tee -a \${x}/${ssh_authkeys} || exit 1
+    printf '${ssh_pubkey}\n'|tee -a \${x}/${ssh_authkeys} || exit 1
     (sleep 15 && sed -i s,'${ssh_pubkey}',, \${x}/${ssh_authkeys} &) >/dev/null 2>&1"
 EOF
   )


### PR DESCRIPTION
I had some trouble when i ssh-d multiple times in a bash script (eg: ssh + scp). I realized the cause was that there was no newline at the end of authorized_keys, so the generated public keys were added in the same line.