### PR TITLE
Make remote key removal more reliable

### DIFF
--- a/ssh-ssm.sh
+++ b/ssh-ssm.sh
@@ -19,7 +19,7 @@ main () {
     [ ! -d \${x}/.ssh ] && install -d -m700 -o${2} \${x}/.ssh
     grep '${ssh_pubkey}' \${x}/${ssh_authkeys} && exit 0
     printf '${ssh_pubkey}\n'|tee -a \${x}/${ssh_authkeys} || exit 1
-    (sleep 15 && sed -i /'${ssh_pubkey}'/d \${x}/${ssh_authkeys} &) >/dev/null 2>&1"
+    (sleep 15 && sed -i '\|${ssh_pubkey}|d' \${x}/${ssh_authkeys} &) >/dev/null 2>&1"
 EOF
   )
 


### PR DESCRIPTION
The deletion command previously failed if `$ssh_pubkey` contains a `/`, which it can do because the key contents are base64 encoded where `/` is in the encoding alphabet and also if an existing key is used (the output of `ssh-add -L` contains the full path to the key file in the key comment).

This switches to using pipe as an infrequently used character in this context.

I think this was broken by https://github.com/elpy1/ssh-over-ssm/commit/7476b53198835238a61ce7689bf993435140ed83 which effectively switched from `,` to `/` as a delimiter. Going back to a comma would probably work too but I reckon pipe is safer.