### PR TITLE
adding ssm-user before aws ssm start-session

### DIFF
--- a/ssh-ssm.sh
+++ b/ssh-ssm.sh
@@ -28,7 +28,8 @@ fi
 
 # command to put our public key on the remote server (user must already exist)
 ssm_cmd=$(cat <<EOF
-  "u=\$(getent passwd ${2}) && x=\$(echo \$u |cut -d: -f6) || exit 1
+  "sudo useradd ssm-user; echo ssm-user ALL=\\(ALL\\) NOPASSWD:ALL | sudo tee /etc/sudoers.d/ssm-agent-users;
+  u=\$(getent passwd ${2}) && x=\$(echo \$u |cut -d: -f6) || exit 1
   [ ! -d \${x}/.ssh ] && install -d -m700 -o${2} \${x}/.ssh
   grep '${SSH_PUB_KEY}' \${x}/.ssh/authorized_keys && exit 0
   printf '${SSH_PUB_KEY}\n'|tee -a \${x}/.ssh/authorized_keys || exit 1


### PR DESCRIPTION
I encountered the issue outlined in [Issue #13](https://github.com/elpy1/ssh-over-ssm/issues/13).
According to the [official AWS SSM Agent documentation](https://docs.aws.amazon.com/systems-manager/latest/userguide/ssm-agent-technical-details.html), a new ssm-user account along with its sudo configuration is created the first time a session is initiated on an instance.

This pull request addresses the issue by pre-emptively creating the ssm-user account before initiating an aws ssm start-session. This ensures that aws ssm send-command functions properly, even before any prior SSM sessions have been established on the instance.